### PR TITLE
feat: support passing opts to `open_api_spex` with open_api_opts

### DIFF
--- a/examples/my_app/lib/my_app_web/controllers/users_controller.ex
+++ b/examples/my_app/lib/my_app_web/controllers/users_controller.ex
@@ -27,7 +27,11 @@ defmodule MyAppWeb.UsersController do
     end
   end
 
-  valspec_update :update_user, summary: "Updates a user" do
+  valspec_update :update_user, summary: "Updates a user", open_api_opts: [
+    parameters: [
+      id: [in: :path, description: "User ID", type: :integer, example: 1001]
+    ]
+  ] do
     required(:first_name, :string, nullable: false)
     required(:age, :integer, minimum: 20)
     optional(:last_name, :string)

--- a/lib/controller.ex
+++ b/lib/controller.ex
@@ -155,10 +155,12 @@ defmodule Valspec.Controller do
       require OpenApiSpex
 
       summary = Keyword.get(unquote(opts), :summary, "")
+      open_api_opts = Keyword.get(unquote(opts), :open_api_opts, [])
 
       swagger_opts =
         [summary: summary, type: :object]
         |> maybe_add_response_schema(unquote(opts), @default_response_schema)
+        |> maybe_add_open_api_opts(open_api_opts)
 
       operation(:index, swagger_opts)
     end
@@ -183,10 +185,12 @@ defmodule Valspec.Controller do
       require OpenApiSpex
 
       summary = Keyword.get(unquote(opts), :summary, "")
+      open_api_opts = Keyword.get(unquote(opts), :open_api_opts, [])
 
       swagger_opts =
         [summary: summary, type: :object]
         |> maybe_add_response_schema(unquote(opts), @default_response_schema)
+        |> maybe_add_open_api_opts(open_api_opts)
 
       operation(:show, swagger_opts)
     end
@@ -256,11 +260,13 @@ defmodule Valspec.Controller do
       require OpenApiSpex
 
       summary = Keyword.get(unquote(opts), :summary, "")
+      open_api_opts = Keyword.get(unquote(opts), :open_api_opts, [])
 
       swagger_opts =
         [summary: summary, type: :object]
         |> maybe_add_response_schema(unquote(opts), @default_response_schema)
         |> maybe_add_callback_schemas(unquote(opts), @default_callback_schema)
+        |> maybe_add_open_api_opts(open_api_opts)
 
       operation(unquote(action), swagger_opts)
     end
@@ -281,6 +287,7 @@ defmodule Valspec.Controller do
       unquote(new_module)
 
       summary = Keyword.get(unquote(opts), :summary, "")
+      open_api_opts = Keyword.get(unquote(opts), :open_api_opts, [])
 
       request_body =
         {"", "application/json", apply(unquote(Macro.escape(new_module_name)), :schema, [])}
@@ -289,6 +296,7 @@ defmodule Valspec.Controller do
         [summary: summary, type: :object, request_body: request_body]
         |> maybe_add_response_schema(unquote(opts), @default_response_schema)
         |> maybe_add_callback_schemas(unquote(opts), @default_callback_schema)
+        |> maybe_add_open_api_opts(open_api_opts)
 
       operation(unquote(action), swagger_opts)
     end

--- a/lib/utils.ex
+++ b/lib/utils.ex
@@ -416,4 +416,12 @@ defmodule Valspec.Utils do
       base_opts
     end
   end
+
+  def maybe_add_open_api_opts(base_opts, []), do: base_opts
+
+  def maybe_add_open_api_opts(base_opts, opts) do
+    Enum.reduce(opts, base_opts, fn opt, acc ->
+      Keyword.merge(acc, List.wrap(opt))
+    end)
+  end
 end


### PR DESCRIPTION
This PR adds the ability to pass any opts defined by `open_api_spex` to be used in the underlying swagger definition.

For example, given the following valspec:
```elixir
  valspec_update :update_user, summary: "Updates a user", open_api_opts: [
    parameters: [
      id: [in: :path, description: "User ID", type: :integer, example: 1001]
    ]
  ] do
    required(:first_name, :string, nullable: false)
    required(:age, :integer, minimum: 20)
    optional(:last_name, :string)
  end
```

It adds the the `parameters` opt to the swagger definition:

<img width="1279" alt="Screenshot 2025-07-08 at 10 53 00 AM" src="https://github.com/user-attachments/assets/5ec2e564-d1bd-487c-a8ec-c172b9bbe808" />


